### PR TITLE
Handle back button and tap outside billing window

### DIFF
--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
@@ -7,6 +7,8 @@ import android.os.Bundle
 import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import android.view.MotionEvent
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.TextView
 import com.android.billingclient.api.BillingClient.BillingResponse
@@ -74,6 +76,24 @@ class DebugBillingActivity : AppCompatActivity() {
       broadcastResult(BillingResponse.OK, buildResultBundle(item.toPurchaseData(this, skuType)))
       finish()
     }
+    window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL)
+    window.addFlags(WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH)
+  }
+
+  override fun onBackPressed() {
+    broadcastUserCanceled()
+    super.onBackPressed()
+  }
+
+  override fun onTouchEvent(event: MotionEvent?): Boolean {
+    if (event?.action == MotionEvent.ACTION_OUTSIDE) {
+        broadcastUserCanceled()
+    }
+    return super.onTouchEvent(event)
+  }
+
+  private fun broadcastUserCanceled() {
+    broadcastResult(BillingResponse.USER_CANCELED, Bundle())
   }
 
   private fun buildResultBundle(purchase: Purchase): Bundle {

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
@@ -42,18 +42,22 @@ class DebugBillingClient(context: Context,
 
   private val broadcastReceiver = object : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-      // Receiving the result from local broadcast and triggering a callback on listener.
-      @BillingResponse
-      val responseCode = intent?.getIntExtra(DebugBillingActivity.RESPONSE_CODE, BillingResponse.ERROR)
-          ?: BillingResponse.ERROR
-      val resultData = intent?.getBundleExtra(DebugBillingActivity.RESPONSE_BUNDLE)
-      val purchases = BillingHelper.extractPurchases(resultData)
+        // Receiving the result from local broadcast and triggering a callback on listener.
+        @BillingResponse
+        val responseCode = intent?.getIntExtra(DebugBillingActivity.RESPONSE_CODE, BillingResponse.ERROR)
+                ?: BillingResponse.ERROR
 
-      // save the purchase
-      purchases.forEach { billingStore.addPurchase(it) }
+        var purchases: List<Purchase>? = null
+        if (responseCode == BillingResponse.OK) {
+            val resultData = intent?.getBundleExtra(DebugBillingActivity.RESPONSE_BUNDLE)
+            purchases = BillingHelper.extractPurchases(resultData)
 
-      // save the result
-      purchasesUpdatedListener.onPurchasesUpdated(responseCode, purchases)
+            // save the purchase
+            purchases.forEach { billingStore.addPurchase(it) }
+        }
+  
+        // save the result
+        purchasesUpdatedListener.onPurchasesUpdated(responseCode, purchases)
     }
   }
 


### PR DESCRIPTION
Add handling for back button and clicking outside billing window.
Update `DebugBillingClient.kt` to handle empty `Bundle()` in response.