### PR TITLE
Add support for minSdkVersion 19

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 ext {
   compileSdkVersion = 27
   buildToolsVersion = "27.1.0"
-  minSdkVersion = 21
+  minSdkVersion = 19
   targetSdkVersion = 27
 
   def archVersion = '1.1.1'
@@ -27,7 +27,7 @@ ext {
       kotlinRuntime             : "org.jetbrains.kotlin:kotlin-runtime:$kotlin_version",
       kotlinTest                : 'org.jetbrains.kotlin:kotlin-test:1.0.6',
       mockitoKotlin             : "com.nhaarman:mockito-kotlin:1.5.0",
-      threeTenABP                 : 'com.jakewharton.threetenabp:threetenabp:1.0.5',
+      threeTenABP               : 'com.jakewharton.threetenabp:threetenabp:1.0.5',
       truth                     : "com.google.truth:truth:0.34",
   ]
 }

--- a/library/src/main/res/layout/activity_debug_billing.xml
+++ b/library/src/main/res/layout/activity_debug_billing.xml
@@ -28,8 +28,7 @@
       android:layout_marginEnd="16dp"
       app:layout_constraintRight_toRightOf="parent"
       android:id="@+id/price"
-      android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-      android:textColor="?android:attr/colorAccent"
+      style="@style/BillingX.Text.Price"
       />
   <TextView
       android:layout_width="0dp"

--- a/library/src/main/res/values-v21/styles.xml
+++ b/library/src/main/res/values-v21/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="BillingX.Text.Price" parent="TextAppearance.AppCompat.Medium">
-        <item name="android:textColor">?android:attr/colorAccent</item>
-    </style>
+  <style name="BillingX.Text.Price" parent="TextAppearance.AppCompat.Medium">
+    <item name="android:textColor">?android:attr/colorAccent</item>
+  </style>
 </resources>

--- a/library/src/main/res/values-v21/styles.xml
+++ b/library/src/main/res/values-v21/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BillingX.Text.Price" parent="TextAppearance.AppCompat.Medium">
+        <item name="android:textColor">?android:attr/colorAccent</item>
+    </style>
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,7 +4,6 @@
     <item name="windowActionBar">false</item>
     <item name="windowNoTitle">true</item>
   </style>
-
   <style name="BillingX.Text.Price" parent="TextAppearance.AppCompat.Medium">
     <item name="android:textColor">?android:attr/textColorSecondary</item>
   </style>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,4 +4,8 @@
     <item name="windowActionBar">false</item>
     <item name="windowNoTitle">true</item>
   </style>
+
+  <style name="BillingX.Text.Price" parent="TextAppearance.AppCompat.Medium">
+    <item name="android:textColor">?android:attr/textColorSecondary</item>
+  </style>
 </resources>


### PR DESCRIPTION
After running lint the only api that was used by `minSdkVersion=21` was used to set text color (`android:textColor="?android:attr/colorAccent"`). This fix allows to use `minSdkVersion=19`. 