### PR TITLE
Fix dialog not dismissed after tap outside

### DIFF
--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
@@ -87,7 +87,9 @@ class DebugBillingActivity : AppCompatActivity() {
 
   override fun onTouchEvent(event: MotionEvent?): Boolean {
     if (event?.action == MotionEvent.ACTION_OUTSIDE) {
-        broadcastUserCanceled()
+      broadcastUserCanceled()
+      finish()
+      return true
     }
     return super.onTouchEvent(event)
   }


### PR DESCRIPTION
On some devices tapping outside purchase dialog does not stop activity. It will also keep sending results to originator. This fix ensures that dialog window is closed and activity is finished after tapping outside of the window. 

(non-exhaustive) list of devices with this issue:
Samsung S5, Android 6.0.1
Samsung S8, Android 7.0
Moto G5 Plus, Android 7.0
