### PR TITLE
Support Play Billing Library v3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
       archLifecycleViewModel    : "androidx.lifecycle:lifecycle-viewmodel-ktx:${lifecycleVersion}",
       archLifecycleLiveData     : "androidx.lifecycle:lifecycle-livedata-ktx:${lifecycleVersion}",
       archLifecycleRuntime      : "androidx.lifecycle:lifecycle-runtime:${lifecycleVersion}",
-      billingClient             : 'com.android.billingclient:billing:2.2.1',
+      billingClient             : 'com.android.billingclient:billing:3.0.3',
       billingX                  : project(':library'),
       constraintLayout          : 'androidx.constraintlayout:constraintlayout:2.0.4',
       design                    : 'com.google.android.material:material:1.3.0',

--- a/example/src/main/java/com/pixite/billingx/BillingManager.kt
+++ b/example/src/main/java/com/pixite/billingx/BillingManager.kt
@@ -62,7 +62,7 @@ class BillingManager(private val activity: FragmentActivity,
       // load local purchases from the cache
       executors.networkIO.execute {
         val purchases = billingClient.queryPurchases(SkuType.SUBS)
-        val validPurchase = purchases.purchasesList.find { SKU_SUBS == it.sku }
+        val validPurchase = purchases.purchasesList?.find { SKU_SUBS == it.sku }
         if (validPurchase != null) {
           subscriptionRepo.setSubscribed(true)
         } else {
@@ -74,7 +74,7 @@ class BillingManager(private val activity: FragmentActivity,
 
   fun restorePurchases() {
     executeServiceRequest {
-      findValidSubscription(billingClient.queryPurchases(SkuType.SUBS).purchasesList) {
+      findValidSubscription(billingClient.queryPurchases(SkuType.SUBS).purchasesList.orEmpty()) {
         subscriptionRepo.setSubscribed(it != null)
       }
     }
@@ -156,7 +156,7 @@ class BillingManager(private val activity: FragmentActivity,
           return@querySkuDetailsAsync
         }
 
-        callback(skuDetailsList)
+        callback(skuDetailsList.orEmpty())
       }
     }
   }

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
@@ -19,8 +19,6 @@ import com.android.billingclient.api.PriceChangeFlowParams
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
-import com.android.billingclient.api.RewardLoadParams
-import com.android.billingclient.api.RewardResponseListener
 import com.android.billingclient.api.SkuDetailsParams
 import com.android.billingclient.api.SkuDetailsResponseListener
 import com.pixite.android.billingx.DebugBillingClient.ClientState.CLOSED
@@ -204,13 +202,6 @@ class DebugBillingClient(
           activity: Activity,
           priceChangeFlowParams: PriceChangeFlowParams,
           priceChangeConfirmationListener: PriceChangeConfirmationListener) {
-    throw NotImplementedError("This method is not supported")
-  }
-
-  override fun loadRewardedSku(
-          rewardLoadParams: RewardLoadParams,
-          rewardResponseListener: RewardResponseListener
-  ) {
     throw NotImplementedError("This method is not supported")
   }
 

--- a/library/src/test/java/android/text/TextUtils.java
+++ b/library/src/test/java/android/text/TextUtils.java
@@ -27,4 +27,13 @@ public class TextUtils {
     }
     return false;
   }
+
+  /**
+   * Returns true if the string is null or 0-length.
+   * @param str the string to be examined
+   * @return true if str is null or zero length
+   */
+  public static boolean isEmpty(CharSequence str) {
+    return str == null || str.length() == 0;
+  }
 }


### PR DESCRIPTION
- Support Play Billing Library v3
  - https://developer.android.com/google/play/billing/release-notes?hl=en#3-0
  - Removed loadRewardedSku because removed support for reworded SKUs with PBL v3
  - Added isEmpty method to TextUtils because TextUtils.isEmpty is used in the constructor of SkuDetails