### PR TITLE
Support Play Billing Library v4

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
       archLifecycleViewModel    : "androidx.lifecycle:lifecycle-viewmodel-ktx:${lifecycleVersion}",
       archLifecycleLiveData     : "androidx.lifecycle:lifecycle-livedata-ktx:${lifecycleVersion}",
       archLifecycleRuntime      : "androidx.lifecycle:lifecycle-runtime:${lifecycleVersion}",
-      billingClient             : 'com.android.billingclient:billing:3.0.3',
+      billingClient             : 'com.android.billingclient:billing:4.0.0',
       billingX                  : project(':library'),
       constraintLayout          : 'androidx.constraintlayout:constraintlayout:2.0.4',
       design                    : 'com.google.android.material:material:1.3.0',

--- a/example/src/debug/java/com/pixite/billingx/debug/DebugDrawer.kt
+++ b/example/src/debug/java/com/pixite/billingx/debug/DebugDrawer.kt
@@ -48,7 +48,7 @@ class DebugDrawer : Fragment() {
                 PurchaseBuilder(
                     orderId = "abcd123",
                     packageName = ctx.packageName,
-                    sku = BillingManager.SKU_SUBS,
+                    sku = listOf(BillingManager.SKU_SUBS),
                     purchaseTime = Date().time,
                     purchaseToken = "token-123",
                     signature = "foo",

--- a/example/src/debug/java/com/pixite/billingx/debug/DebugDrawer.kt
+++ b/example/src/debug/java/com/pixite/billingx/debug/DebugDrawer.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Switch
 import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -48,7 +47,7 @@ class DebugDrawer : Fragment() {
                 PurchaseBuilder(
                     orderId = "abcd123",
                     packageName = ctx.packageName,
-                    sku = listOf(BillingManager.SKU_SUBS),
+                    skus = listOf(BillingManager.SKU_SUBS),
                     purchaseTime = Date().time,
                     purchaseToken = "token-123",
                     signature = "foo",

--- a/library/src/main/java/com/pixite/android/billingx/BillingStore.kt
+++ b/library/src/main/java/com/pixite/android/billingx/BillingStore.kt
@@ -40,4 +40,8 @@ abstract class BillingStore {
   abstract fun removePurchase(purchaseToken: String): BillingStore
 
   abstract fun acknowledgePurchase(purchaseToken: String)
+
+  abstract fun setConnectionState(@BillingClient.ConnectionState connectionState: Int): BillingStore
+  @BillingClient.ConnectionState
+  abstract fun getConnectionState(): Int
 }

--- a/library/src/main/java/com/pixite/android/billingx/BillingStoreImpl.kt
+++ b/library/src/main/java/com/pixite/android/billingx/BillingStoreImpl.kt
@@ -102,7 +102,7 @@ class BillingStoreImpl(private val prefs: SharedPreferences) : BillingStore(){
   }
 
   override fun getConnectionState(): Int {
-      return prefs.getInt(KEY_CONNECTION_STATE, BillingClient.ConnectionState.CONNECTED)
+      return prefs.getInt(KEY_CONNECTION_STATE, BillingClient.ConnectionState.DISCONNECTED)
   }
 
   private fun Purchase.toJSONObject(): JSONObject =

--- a/library/src/main/java/com/pixite/android/billingx/BillingStoreImpl.kt
+++ b/library/src/main/java/com/pixite/android/billingx/BillingStoreImpl.kt
@@ -17,6 +17,7 @@ class BillingStoreImpl(private val prefs: SharedPreferences) : BillingStore(){
   companion object {
     internal const val KEY_PURCHASES = "dbc_purchases"
     internal const val KEY_SKU_DETAILS = "dbc_sku_details"
+    internal const val KEY_CONNECTION_STATE = "dbc_connection_state"
   }
 
   override fun getSkuDetails(params: SkuDetailsParams): List<SkuDetails> {
@@ -93,6 +94,15 @@ class BillingStoreImpl(private val prefs: SharedPreferences) : BillingStore(){
     val json = JSONArray()
     acknowledgedPurchases?.forEach { json.put(it.toJSONObject()) }
     prefs.edit().putString(KEY_PURCHASES, json.toString()).apply()
+  }
+
+  override fun setConnectionState(connectionState: Int): BillingStore {
+    prefs.edit().putInt(KEY_CONNECTION_STATE, connectionState).apply()
+    return this
+  }
+
+  override fun getConnectionState(): Int {
+      return prefs.getInt(KEY_CONNECTION_STATE, BillingClient.ConnectionState.CONNECTED)
   }
 
   private fun Purchase.toJSONObject(): JSONObject =

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
@@ -55,8 +55,10 @@ class DebugBillingActivity : AppCompatActivity() {
     price = findViewById(R.id.price)
     buyButton = findViewById(R.id.buy)
 
-    val sku = intent.getStringExtra(REQUEST_SKU)
-    skuType = intent.getStringExtra(REQUEST_SKU_TYPE).orEmpty()
+    val skuDetailsJson = intent.getStringArrayExtra(REQUEST_SKU_DETAILS)
+    val skuDetails: SkuDetails? = skuDetailsJson?.map { SkuDetails(it) }.orEmpty().getOrNull(0)
+    val sku = skuDetails?.sku.orEmpty()
+    skuType = skuDetails?.type.orEmpty()
     val items = BillingStore.defaultStore(this)
         .getSkuDetails(SkuDetailsParams.newBuilder()
             .setType(skuType)

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingActivity.kt
@@ -16,7 +16,7 @@ import com.android.billingclient.api.BillingClient.SkuType
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.SkuDetails
 import com.android.billingclient.api.SkuDetailsParams
-import java.util.*
+import java.util.Date
 
 class DebugBillingActivity : AppCompatActivity() {
 
@@ -56,22 +56,24 @@ class DebugBillingActivity : AppCompatActivity() {
     buyButton = findViewById(R.id.buy)
 
     val skuDetailsJson = intent.getStringArrayExtra(REQUEST_SKU_DETAILS)
-    val skuDetails: SkuDetails? = skuDetailsJson?.map { SkuDetails(it) }.orEmpty().getOrNull(0)
-    val sku = skuDetails?.sku.orEmpty()
-    skuType = skuDetails?.type.orEmpty()
-    val items = BillingStore.defaultStore(this)
-        .getSkuDetails(SkuDetailsParams.newBuilder()
-            .setType(skuType)
-            .setSkusList(listOf(sku))
-            .build())
-        .associate { it.sku to it }
-    val it = items[sku]
-    if (it == null) {
-      Log.e("DBX", "Unknown $skuType sku: $sku")
+    val skuDetails: List<SkuDetails> = skuDetailsJson?.map { SkuDetails(it) }.orEmpty()
+    skuType = skuDetails.getOrNull(0)?.type.orEmpty()
+    val skus = skuDetails.map { it.sku }
+    if (skuType.isEmpty() || skuDetails.isEmpty()) {
+      Log.e("DBX", "Unknown $skuType skus: $skus")
       finish()
       return
     }
-    item = it
+    val items = BillingStore.defaultStore(this)
+        .getSkuDetails(SkuDetailsParams.newBuilder()
+            .setType(skuType)
+            .setSkusList(skus)
+            .build())
+        .associate { it.sku to it }
+    // TODO If you want to create a Multi-line subscriptions screen, modify this process
+    val firstSku = skus[0]
+    val firstSkuDetails = items[firstSku] ?: return
+    item = firstSkuDetails
     title.text = item.title
     description.text = item.description
     price.text = item.price

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
@@ -218,7 +218,7 @@ class DebugBillingClient(
   }
 
   override fun getConnectionState(): Int {
-    TODO("Not yet implemented")
+    return billingStore.getConnectionState()
   }
 
   override fun queryPurchasesAsync(skuType: String, listener: PurchasesResponseListener) {

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
@@ -18,7 +18,9 @@ import com.android.billingclient.api.PriceChangeConfirmationListener
 import com.android.billingclient.api.PriceChangeFlowParams
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryResponseListener
+import com.android.billingclient.api.PurchasesResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
+import com.android.billingclient.api.SkuDetails
 import com.android.billingclient.api.SkuDetailsParams
 import com.android.billingclient.api.SkuDetailsResponseListener
 import com.pixite.android.billingx.DebugBillingClient.ClientState.CLOSED
@@ -153,8 +155,9 @@ class DebugBillingClient(
 
   override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult {
     val intent = Intent(activity, DebugBillingActivity::class.java)
-    intent.putExtra(DebugBillingActivity.REQUEST_SKU_TYPE, params.skuType)
-    intent.putExtra(DebugBillingActivity.REQUEST_SKU, params.sku)
+    val skuDetails: List<SkuDetails> = params.zzj()
+    val skuDetailsJson: Array<String> = skuDetails.map { it.originalJson }.toTypedArray()
+    intent.putExtra(DebugBillingActivity.REQUEST_SKU_DETAILS, skuDetailsJson)
     activity.startActivity(intent)
     return BillingResponseCode.OK.toBillingResult()
   }
@@ -212,6 +215,14 @@ class DebugBillingClient(
       billingStore.acknowledgePurchase(acknowledgePurchaseParams.purchaseToken)
       acknowledgePurchaseResponseListener
               .onAcknowledgePurchaseResponse(BillingResponseCode.OK.toBillingResult())
+  }
+
+  override fun getConnectionState(): Int {
+    TODO("Not yet implemented")
+  }
+
+  override fun queryPurchasesAsync(skuType: String, listener: PurchasesResponseListener) {
+    TODO("Not yet implemented")
   }
 
   // Supplied for easy Java interop.

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
@@ -148,7 +148,11 @@ class DebugBillingClient(
 
   override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult {
     val intent = Intent(activity, DebugBillingActivity::class.java)
-    val skuDetails: List<SkuDetails> = params.zzj()
+    val skuDetails: List<SkuDetails> = BillingFlowParams::class.java.declaredMethods
+      .find {
+        it.genericReturnType.toString() == "java.util.ArrayList<com.android.billingclient.api.SkuDetails>"
+      }?.let { it.invoke(params) as? List<SkuDetails> }
+      .orEmpty()
     val skuDetailsJson: Array<String> = skuDetails.map { it.originalJson }.toTypedArray()
     intent.putExtra(DebugBillingActivity.REQUEST_SKU_DETAILS, skuDetailsJson)
     activity.startActivity(intent)

--- a/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
+++ b/library/src/main/java/com/pixite/android/billingx/DebugBillingClient.kt
@@ -148,6 +148,8 @@ class DebugBillingClient(
 
   override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult {
     val intent = Intent(activity, DebugBillingActivity::class.java)
+    // FIXME: Once the Play Billing Library has been fixed, modify the following code.
+    // https://issuetracker.google.com/issues/191995386
     val skuDetails: List<SkuDetails> = BillingFlowParams::class.java.declaredMethods
       .find {
         it.genericReturnType.toString() == "java.util.ArrayList<com.android.billingclient.api.SkuDetails>"

--- a/library/src/main/java/com/pixite/android/billingx/PurchaseBuilder.kt
+++ b/library/src/main/java/com/pixite/android/billingx/PurchaseBuilder.kt
@@ -6,7 +6,7 @@ import org.json.JSONObject
 data class PurchaseBuilder(
         val orderId: String? = null,
         val packageName: String? = null,
-        val sku: List<String>,
+        val skus: List<String>,
         val purchaseTime: Long,
         val purchaseToken: String,
         val signature: String,
@@ -20,7 +20,11 @@ data class PurchaseBuilder(
     val json = JSONObject()
     orderId?.let { json.put("orderId", it) }
     packageName?.let { json.put("packageName", it) }
-    json.put("productId", sku)
+    if (skus.size > 1) {
+      json.put("productIds", skus)
+    } else {
+      json.put("productId", skus.first())
+    }
     json.put("purchaseTime", purchaseTime)
     json.put("purchaseToken", purchaseToken)
     json.put("acknowledged", acknowledged)
@@ -35,7 +39,7 @@ data class PurchaseBuilder(
       return PurchaseBuilder(
               orderId = purchase.orderId,
               packageName = purchase.packageName,
-              sku = purchase.skus,
+              skus = purchase.skus,
               purchaseTime = purchase.purchaseTime,
               purchaseToken = purchase.purchaseToken,
               signature = purchase.signature,

--- a/library/src/main/java/com/pixite/android/billingx/PurchaseBuilder.kt
+++ b/library/src/main/java/com/pixite/android/billingx/PurchaseBuilder.kt
@@ -6,7 +6,7 @@ import org.json.JSONObject
 data class PurchaseBuilder(
         val orderId: String? = null,
         val packageName: String? = null,
-        val sku: String,
+        val sku: List<String>,
         val purchaseTime: Long,
         val purchaseToken: String,
         val signature: String,
@@ -35,7 +35,7 @@ data class PurchaseBuilder(
       return PurchaseBuilder(
               orderId = purchase.orderId,
               packageName = purchase.packageName,
-              sku = purchase.sku,
+              sku = purchase.skus,
               purchaseTime = purchase.purchaseTime,
               purchaseToken = purchase.purchaseToken,
               signature = purchase.signature,

--- a/library/src/test/java/com/pixite/android/billingx/DebugBillingClientTest.kt
+++ b/library/src/test/java/com/pixite/android/billingx/DebugBillingClientTest.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
+import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingClient.FeatureType
 import com.android.billingclient.api.BillingClient.SkuType
@@ -103,6 +104,8 @@ class DebugBillingClientTest {
   private val subs2 = SkuDetails(subs2Json)
   private val inapp1 = SkuDetails(inapp1Json)
 
+  private var connectionState: Int = BillingClient.ConnectionState.DISCONNECTED
+
   @Before fun setup() {
     application = mock()
     activity = mock {
@@ -121,6 +124,11 @@ class DebugBillingClientTest {
           else -> throw IllegalArgumentException("Unknown skuType: ${params.skuType}")
         }.filter { it.sku in params.skusList }
       }
+      on { setConnectionState(any()) } doAnswer {
+        connectionState = it.arguments.first() as Int
+        this.mock
+      }
+      on { getConnectionState() } doAnswer { connectionState }
     }
     purchasesUpdatedListener = FakePurchasesUpdatedListener()
     client = DebugBillingClient(activity, purchasesUpdatedListener,


### PR DESCRIPTION
This PR contains the diff for #14.

- Support Play Billing Library v4
    - https://developer.android.com/google/play/billing/release-notes?hl=en#4-0
    - Implement queryPurchasesAsync in DebugBillingClient
    - BillingClient.queryPurchases is deprecated, but leave it in place until it removes
    - We will not create a purchase screen for Multi-line subscriptions this time
    - Add getter and setter of ConnectionState to BillingStore for ConnectionState added since PBLv4
